### PR TITLE
A few simplifications

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -11,7 +11,6 @@ use std::collections::VecDeque;
 use std::collections::HashMap;
 use std::cmp::Ordering;
 use std::cell::{Cell, RefCell};
-use std::mem;
 
 #[cfg(test)]
 mod test;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -276,11 +276,9 @@ pub fn astar<S: SearchProblem>(s: &mut S) -> Option<VecDeque<S::Node>> where S::
     let mut heap: BinaryHeap<&SearchNode<S::Node, S::Cost>> = BinaryHeap::new();
 
     let start_state: &S::Node = state_arena.alloc(s.start());
+    let start_node: &SearchNode<S::Node, S::Cost> = node_arena.alloc(SearchNode::new_initial(start_state));
 
-    let start_node: SearchNode<S::Node, S::Cost> = SearchNode::new_initial(start_state);
-    let start_node: &SearchNode<S::Node, S::Cost> = node_arena.alloc(start_node);
     state_to_node.insert(start_state, start_node);
-
     heap.push(start_node);
 
     let mut found = None;


### PR DESCRIPTION
I realized I had these sitting around for a while on my own branch. Cleaning up some code, and thought you might like them. (Avoids the warning about the now-unused `std::mem`, and removes the `let` binding that shadows the line before it, which I find pretty confusing.)
