### PR TITLE
Add a test for TwoDSearchProblem

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -11,7 +11,6 @@ use std::collections::VecDeque;
 use std::collections::HashMap;
 use std::cmp::Ordering;
 use std::cell::{Cell, RefCell};
-use std::mem;
 
 #[cfg(test)]
 mod test;

--- a/src/test.rs
+++ b/src/test.rs
@@ -28,8 +28,8 @@ impl SearchProblem for GridState {
     }
     fn neighbors(&mut self, &(x, y): &(i32, i32)) -> IntoIter<((i32, i32), i32)> {
         let mut vec = vec![];
-        for i in (-1 .. 1 + 1) {
-            for k in (-1 .. 1 + 1) {
+        for i in -1 .. 1 + 1 {
+            for k in -1 .. 1 + 1 {
                 if !(i == 0 && k == 0) {
                     vec.push(((x + i, y + k), 1));
                 }
@@ -64,19 +64,19 @@ fn test_iter() {
 #[test]
 fn test_start_end() {
     let p = path((0,0), (0,0)).unwrap();
-    assert!(p == vec![(0, 0)].into_iter().collect());
+    assert_eq!(p, vec![(0, 0)].into_iter().collect());
 }
 
 #[test]
 fn test_next() {
     let p = path((0,0), (0,1)).unwrap();
-    assert!(p == vec![(0,0), (0,1)].into_iter().collect());
+    assert_eq!(p, vec![(0,0), (0,1)].into_iter().collect());
 }
 
 #[test]
 fn test_few() {
     let p = path((0,0), (0,4)).unwrap();
-    assert!(p == vec![(0,0), (0,1) ,(0,2), (0,3), (0,4)].into_iter().collect());
+    assert_eq!(p, vec![(0,0), (0,1) ,(0,2), (0,3), (0,4)].into_iter().collect());
 }
 
 struct Maze {

--- a/src/test.rs
+++ b/src/test.rs
@@ -1,4 +1,4 @@
-use super::{astar, SearchProblem};
+use super::{astar, SearchProblem, TwoDSearchProblem, ReusableSearchProblem};
 use std::collections::VecDeque;
 use std::vec::IntoIter;
 
@@ -77,4 +77,72 @@ fn test_next() {
 fn test_few() {
     let p = path((0,0), (0,4)).unwrap();
     assert!(p == vec![(0,0), (0,1) ,(0,2), (0,3), (0,4)].into_iter().collect());
+}
+
+struct Maze {
+    xmax: i32,
+    ymax: i32
+}
+
+impl TwoDSearchProblem for Maze {
+    fn get(&mut self, x: i32, y: i32) -> Option<u32> {
+        /* Imagine a simple maze, that looks something like this:
+        .
+        ........
+               .
+        ........
+        .
+        ........
+        where . is passable, and everywhere else is impassible.
+        */
+        if x < 0 || x > self.xmax || y < 0 || y > self.ymax {
+            None
+        } else if y % 4 == 0 && x > 0 {
+            None
+        } else if (y + 2) % 4 == 0 && x < self.xmax {
+            None
+        } else {
+            Some(0)
+        }
+    }
+}
+
+#[test]
+fn test_maze() {
+    let mut maze = Maze{ xmax: 7, ymax: 5 };
+    /* If this test fails, try printing out the maze using this code:
+    println!("");
+    for y in 0 .. maze.ymax+1 {
+        for x in 0 .. maze.xmax+1 {
+            match maze.get(x, y) {
+                Some(_) => print!("."),
+                None => print!(" "),
+            }
+        }
+        println!("");
+    }
+    */
+    let p = astar(&mut maze.search((0,0), (0,4))).unwrap();
+    assert_eq!(p, vec![
+        (0, 0),
+        (0, 1), (1, 1), (2, 1), (3, 1), (4, 1), (5, 1), (6, 1), (7, 1),
+        (7, 2),
+        (7, 3), (6, 3), (5, 3), (4, 3), (3, 3), (2, 3), (1, 3), (0, 3),
+        (0, 4)].into_iter().collect());
+}
+
+#[test]
+fn test_maze_reusable() {
+    let mut maze = Maze{ xmax: 7, ymax: 5 };
+    let p = astar(&mut maze.search((0,0), (0,4))).unwrap();
+    let p2 = astar(&mut maze.search((0,0), (0,4))).unwrap();
+    assert_eq!(p, p2);
+}
+
+#[test]
+fn test_maze_reverse() {
+    let mut maze = Maze{ xmax: 7, ymax: 5 };
+    let p = astar(&mut maze.search((0,0), (0,4))).unwrap();
+    let p2 = astar(&mut maze.search((0,4), (0,0))).unwrap();
+    assert_eq!(p, p2.into_iter().rev().collect());
 }


### PR DESCRIPTION
It took me a while to work out how TwoDSearchProblem was supposed to be used, so I wrote a simple example for others to follow.

I also squashed some compiler warnings while I was there, and converted tests to use assert_eq!(a, b) rather than assert!(a == b). I've left this as a separate commit though, so you can cherry-pick however you like.